### PR TITLE
need relative path for required module

### DIFF
--- a/src/Microsoft.PowerShell.GraphicalTools/Microsoft.PowerShell.GraphicalTools.psd1
+++ b/src/Microsoft.PowerShell.GraphicalTools/Microsoft.PowerShell.GraphicalTools.psd1
@@ -48,7 +48,7 @@ PowerShellVersion = '6.2'
 # ProcessorArchitecture = ''
 
 # Modules that must be imported into the global environment prior to importing this module
-RequiredModules = @( 'Microsoft.PowerShell.GraphicalTools.psm1' )
+RequiredModules = @( './Microsoft.PowerShell.GraphicalTools.psm1' )
 
 # Assemblies that must be loaded prior to importing this module
 # RequiredAssemblies = @()


### PR DESCRIPTION
Since the `RequiredModules` didn't include a path, PowerShell was looking through `$env:PSModulePath` to find it and didn't so got error:

```powershell
ipmo : The required module 'Microsoft.PowerShell.GraphicalTools.psm1' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '/Users/steve/repos/GraphicalTools/module/Microsoft.PowerShell.GraphicalTools/Microsoft.PowerShell.GraphicalTools.psd1'.
At line:1 char:1
+ ipmo ./Microsoft.PowerShell.GraphicalTools.psd1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : ResourceUnavailable: (/Users/steve/repos/\u2026GraphicalTools.psd1:String) [Import-Module], MissingMemberException
+ FullyQualifiedErrorId : Modules_InvalidManifest,Microsoft.PowerShell.Commands.ImportModuleCommand
```

Fix is to use a relative path so that `Import-Module` finds it correctly if it's not in your `$env:PSModulePath`