### PR TITLE
Add PowerShellVersion format call fallback

### DIFF
--- a/src/Microsoft.PowerShell.GraphicalTools/TypeGetter.cs
+++ b/src/Microsoft.PowerShell.GraphicalTools/TypeGetter.cs
@@ -25,8 +25,17 @@ namespace OutGridView.Cmdlet
 
             var types = _cmdlet.InvokeCommand.InvokeScript("Get-FormatData " + typeName).ToList();
 
-            //No custom type definitions found
-            if (types == null || types.Count == 0) return null;
+            //No custom type definitions found - try the PowerShell specific format data
+            if (types == null || types.Count == 0) 
+            {
+                types = _cmdlet.InvokeCommand
+                    .InvokeScript("Get-FormatData -PowerShellVersion $PSVersionTable.PSVersion " + typeName).ToList();
+
+                if (types == null || types.Count == 0)
+                {
+                    return null;
+                }
+            }
 
             var extendedTypeDefinition = types[0].BaseObject as ExtendedTypeDefinition;
 

--- a/src/Microsoft.PowerShell.GraphicalTools/TypeGetter.cs
+++ b/src/Microsoft.PowerShell.GraphicalTools/TypeGetter.cs
@@ -23,13 +23,13 @@ namespace OutGridView.Cmdlet
         {
             var typeName = obj.BaseObject.GetType().FullName;
 
-            var types = _cmdlet.InvokeCommand.InvokeScript("Get-FormatData " + typeName).ToList();
+            var types = _cmdlet.InvokeCommand.InvokeScript(@"Microsoft.PowerShell.Utility\Get-FormatData " + typeName).ToList();
 
             //No custom type definitions found - try the PowerShell specific format data
             if (types == null || types.Count == 0) 
             {
                 types = _cmdlet.InvokeCommand
-                    .InvokeScript("Get-FormatData -PowerShellVersion $PSVersionTable.PSVersion " + typeName).ToList();
+                    .InvokeScript(@"Microsoft.PowerShell.Utility\Get-FormatData -PowerShellVersion $PSVersionTable.PSVersion " + typeName).ToList();
 
                 if (types == null || types.Count == 0)
                 {


### PR DESCRIPTION
I found out one day that there is different format data that is returned when `-PowerShellVersion` is specified in `Get-FormatData`. I don't entirely know why... but that's the way it is.

As such, I've added a fallback to search through that as well if running `Get-FormatData` on its own returns nothing.

Here's the before and after on:

```
gci | ogv
```

Before (vertical scroll bar - yuck):
![image](https://user-images.githubusercontent.com/2644648/66363736-1750ed80-e93c-11e9-8a71-bda306a856e4.png)


After:

![image](https://user-images.githubusercontent.com/2644648/66363536-73674200-e93b-11e9-8e2e-c781e96e6668.png)
