### PR TITLE
Use -noprofile in Build.ps1 to reduce load time

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,2 +1,2 @@
 Invoke-Build Build
-pwsh -c "Import-Module '$PSScriptRoot/module/Microsoft.PowerShell.GraphicalTools'; Get-Process | Out-GridView -PassThru"
+pwsh -noprofile -command "Import-Module '$PSScriptRoot/module/Microsoft.PowerShell.GraphicalTools'; Get-Process | Out-GridView -PassThru"


### PR DESCRIPTION
This reduces load time on systems with a `$profile` that takes time to load (mine takes 5+ seconds)