### PR TITLE
Change ConsoleGridView column width to be dynamic

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,7 +30,8 @@
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",
-            "processId": "${command:pickProcess}"
+            "processId": "${command:pickProcess}",
+            "justMyCode": false
         }
     ]
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -57,19 +57,17 @@ namespace OutGridView.Cmdlet
 
             var gridHeaders = applicationData.DataTable.DataColumns.Select((c) => c.Label).ToList();
             var columnWidths = new int[gridHeaders.Count];
-            int index = 0;
-            foreach (var header in gridHeaders)
+            for (int i = 0; i < gridHeaders.Count; i++)
             {
-                columnWidths[index] = header.Length;
-                index++;
+                columnWidths[i] = gridHeaders[i].Length;
             }
-
 
             // calculate the width of each column based on longest string in each column for each row
             foreach (var row in applicationData.DataTable.Data)
             {
-                index = 0;
-                foreach (var col in row.Values)
+                int index = 0;
+                // use just the first 20 rows to calculate in case there is a large dataset
+                foreach (var col in row.Values.Take(20))
                 {
                     var len = col.Value.DisplayValue.Length;
                     if (len > columnWidths[index])
@@ -88,11 +86,13 @@ namespace OutGridView.Cmdlet
             // if the total width is wider than the usable width, remove 1 from widest column until it fits
             // the gui loses 3 chars on the left and 2 chars on the right
             int usableWidth = top.Frame.Width - 3 - columnWidths.Length - offset - 2;
-            while (columnWidths.Sum() >= usableWidth)
+            int columnWidthsSum = columnWidths.Sum();
+            while (columnWidthsSum >= usableWidth)
             {
                 int maxWidth = columnWidths.Max();
                 int maxIndex = columnWidths.ToList().IndexOf(maxWidth);
                 columnWidths[maxIndex]--;
+                columnWidthsSum--;
             }
 
             win.Add(new Label(GetPaddedString(gridHeaders, columnWidths, offset + offset - 1)));
@@ -155,26 +155,23 @@ namespace OutGridView.Cmdlet
                 builder.Append(string.Empty.PadRight(offset));
             }
 
-            int index = 0;
-            foreach (var str in strings)
+            for (int i = 0; i < strings.Count; i++)
             {
-                if (index > 0)
+                if (i > 0)
                 {
                     builder.Append(' ');
                 }
 
                 // If the string won't fit in the column, append an ellipsis.
-                if (str.Length > colWidths[index])
+                if (strings[i].Length > colWidths[i])
                 {
-                    builder.Append(str.Substring(0, colWidths[index] - 4));
+                    builder.Append(strings[i].Substring(0, colWidths[i] - 4));
                     builder.Append("...");
                 }
                 else
                 {
-                    builder.Append(str.PadRight(colWidths[index]));
+                    builder.Append(strings[i].PadRight(colWidths[i]));
                 }
-
-                index++;
             }
 
             return builder.ToString();

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -89,8 +89,17 @@ namespace OutGridView.Cmdlet
             int columnWidthsSum = columnWidths.Sum();
             while (columnWidthsSum >= usableWidth)
             {
-                int maxWidth = columnWidths.Max();
-                int maxIndex = columnWidths.ToList().IndexOf(maxWidth);
+                int maxWidth = 0;
+                int maxIndex = 0;
+                for (int i = 0; i < columnWidths.Length; i++)
+                {
+                    if (columnWidths[i] > maxWidth)
+                    {
+                        maxWidth = columnWidths[i];
+                        maxIndex = i;
+                    }
+                }
+
                 columnWidths[maxIndex]--;
                 columnWidthsSum--;
             }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -14,6 +15,7 @@ namespace OutGridView.Cmdlet
         private const string ACCEPT_TEXT = "Are you sure you want to select\nthese items to send down the pipeline?";
         private const string CANCEL_TEXT = "Are you sure you want to cancel?\nNothing will be emitted to the pipeline.";
         private const string CLOSE_TEXT = "Are you sure you want to close?";
+        private readonly int NumberOfObjectsToInspect = Console.WindowHeight / 2;
 
         private bool _cancelled;
 
@@ -66,8 +68,7 @@ namespace OutGridView.Cmdlet
             foreach (var row in applicationData.DataTable.Data)
             {
                 int index = 0;
-                // use just the first 20 rows to calculate in case there is a large dataset
-                foreach (var col in row.Values.Take(20))
+                foreach (var col in row.Values.Take(NumberOfObjectsToInspect))
                 {
                     var len = col.Value.DisplayValue.Length;
                     if (len > columnWidths[index])
@@ -168,6 +169,7 @@ namespace OutGridView.Cmdlet
             {
                 if (i > 0)
                 {
+                    // Add a space between columns
                     builder.Append(' ');
                 }
 

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -15,8 +15,6 @@ namespace OutGridView.Cmdlet
         private const string ACCEPT_TEXT = "Are you sure you want to select\nthese items to send down the pipeline?";
         private const string CANCEL_TEXT = "Are you sure you want to cancel?\nNothing will be emitted to the pipeline.";
         private const string CLOSE_TEXT = "Are you sure you want to close?";
-        private readonly int NumberOfObjectsToInspect = Console.WindowHeight / 2;
-
         private bool _cancelled;
 
         internal HashSet<int> SelectedIndexes { get; private set; } = new HashSet<int>();
@@ -68,7 +66,9 @@ namespace OutGridView.Cmdlet
             foreach (var row in applicationData.DataTable.Data)
             {
                 int index = 0;
-                foreach (var col in row.Values.Take(NumberOfObjectsToInspect))
+
+                // use half of the visible buffer height for the number of objects to inspect to calculate widths
+                foreach (var col in row.Values.Take(top.Frame.Height / 2))
                 {
                     var len = col.Value.DisplayValue.Length;
                     if (len > columnWidths[index])


### PR DESCRIPTION
Currently, the column widths is simply the total width divided by the number of columns.  Change is to calculate the column widths based on the header and the max width of the content then trimming the width by the widest column until the total width fits in the GUI.

Also updated the launch config to enable attached debugging.

![img](https://i.imgur.com/fnv35mg.png)