### PR TITLE
Set cursor key to application mode

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -132,6 +132,12 @@ namespace OutGridView.Cmdlet
 
             Application.Run();
 
+            // By emitting this, we fix an issue where arrow keys don't work in the console
+            // because .NET requires application mode to support Arrow key escape sequences
+            // Esc[?1h - Set cursor key to application mode
+            // See http://ascii-table.com/ansi-escape-sequences-vt-100.php
+            Console.Write("\u001b[?1h");
+
             if (_cancelled)
             {
                 return;

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -10,7 +10,7 @@ using Terminal.Gui;
 
 namespace OutGridView.Cmdlet
 {
-    internal class ConsoleGui
+    internal class ConsoleGui : IDisposable
     {
         private const string ACCEPT_TEXT = "Are you sure you want to select\nthese items to send down the pipeline?";
         private const string CANCEL_TEXT = "Are you sure you want to cancel?\nNothing will be emitted to the pipeline.";
@@ -132,12 +132,6 @@ namespace OutGridView.Cmdlet
 
             Application.Run();
 
-            // By emitting this, we fix an issue where arrow keys don't work in the console
-            // because .NET requires application mode to support Arrow key escape sequences
-            // Esc[?1h - Set cursor key to application mode
-            // See http://ascii-table.com/ansi-escape-sequences-vt-100.php
-            Console.Write("\u001b[?1h");
-
             if (_cancelled)
             {
                 return;
@@ -150,11 +144,6 @@ namespace OutGridView.Cmdlet
                     SelectedIndexes.Add(i);
                 }
             }
-        }
-
-        public void Close()
-        {
-            // top.Running = false;
         }
 
         private static bool Quit(string title, string text)
@@ -192,6 +181,15 @@ namespace OutGridView.Cmdlet
             }
 
             return builder.ToString();
+        }
+
+        public void Dispose()
+        {
+            // By emitting this, we fix an issue where arrow keys don't work in the console
+            // because .NET requires application mode to support Arrow key escape sequences
+            // Esc[?1h - Set cursor key to application mode
+            // See http://ascii-table.com/ansi-escape-sequences-vt-100.php
+            Console.Write("\u001b[?1h");
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -15,7 +15,7 @@ namespace OutGridView.Cmdlet
     /// </summary>
     [Cmdlet(VerbsData.Out, "ConsoleGridView", DefaultParameterSetName = "PassThru")]
     [Alias("ocgv")]
-    public class OutConsoleGridViewCmdletCommand : PSCmdlet
+    public class OutConsoleGridViewCmdletCommand : PSCmdlet, IDisposable
     {
         #region Properties
 
@@ -101,11 +101,6 @@ namespace OutGridView.Cmdlet
             }
         }
 
-        protected override void StopProcessing()
-        {
-            _consoleGui.Close();
-        }
-
         private void ProcessObject(PSObject input)
         {
 
@@ -171,6 +166,11 @@ namespace OutGridView.Cmdlet
                 }
                 this.WriteObject(selectedObject, false);
             }
+        }
+
+        public void Dispose()
+        {
+            _consoleGui.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes #49 

Because .NET requires application mode to support Arrow key escape sequences

Esc[?1h - Set cursor key to application mode
See http://ascii-table.com/ansi-escape-sequences-vt-100.php