### PR TITLE
Add support for regex filter

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -125,7 +125,7 @@ namespace OutGridView.Cmdlet
             {
                 X = Pos.Right(filterLabel) + 1,
                 Y = Pos.Top(filterLabel) + 1,
-                TextColor = Terminal.Gui.Attribute.Make(Color.Red, Color.Blue), // How to get window background color?
+                ColorScheme = Colors.Base,
                 Width = filterFieldWidth
             };
 
@@ -220,7 +220,7 @@ namespace OutGridView.Cmdlet
         {
             var items = new List<string>();
             filterError.Text = " ";
-            filterError.TextColor = Terminal.Gui.Attribute.Make(Color.Red, Color.Blue);  // How to get window background color?
+            filterError.ColorScheme = Colors.Base;
             filterError.Redraw(filterError.Bounds);
 
             foreach (DataTableRow dataTableRow in applicationData.DataTable.Data)
@@ -242,8 +242,8 @@ namespace OutGridView.Cmdlet
                         }
                         catch (Exception ex)
                         {
-                            filterError.Text = ex.Message;  
-                            filterError.TextColor = Terminal.Gui.Attribute.Make(Color.Red, Color.Black);
+                            filterError.Text = ex.Message;
+                            filterError.ColorScheme = Colors.Error;
                             filterError.Redraw(filterError.Bounds);
                             return;
                         }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -39,7 +39,7 @@ namespace OutGridView.Cmdlet
             _listViewOffset = _applicationData.PassThru ? 8 : 4;
 
             // Creates the top-level window to show
-            var win = new Window(_applicationData.Title ?? "Out-ConsoleGridView")
+            var win = new Window(_applicationData.Title)
             {
                 X = 0,
                 Y = 1, // Leave one row for the toplevel menu

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -34,6 +34,10 @@ namespace OutGridView.Cmdlet
             var top = Application.Top;
             _applicationData = applicationData;
 
+            // If we have PassThru, then we want to make them selectable. If we make them selectable,
+            // they have a 8 character addition of a checkbox ("     [ ]") that we have to factor in.
+            _listViewOffset = _applicationData.PassThru ? 8 : 4;
+
             // Creates the top-level window to show
             var win = new Window(_applicationData.Title ?? "Out-ConsoleGridView")
             {
@@ -86,10 +90,6 @@ namespace OutGridView.Cmdlet
                     index++;
                 }
             }
-
-            // If we have PassThru, then we want to make them selectable. If we make them selectable,
-            // they have a 8 character addition of a checkbox ("     [ ]") that we have to factor in.
-            _listViewOffset = _applicationData.PassThru ? 8 : 4;
 
             // if the total width is wider than the usable width, remove 1 from widest column until it fits
             // the gui loses 3 chars on the left and 2 chars on the right
@@ -245,23 +245,20 @@ namespace OutGridView.Cmdlet
                 {
                     string dataValue = dataTableRow.Values[dataTableColumn.ToString()].DisplayValue;
 
-                    if (!match)
+                    try
                     {
-                        try
+                        if (!match && Regex.IsMatch(dataValue, filter, RegexOptions.IgnoreCase))
                         {
-                            if (Regex.IsMatch(dataValue, filter, RegexOptions.IgnoreCase))
-                            {
-                                match = true;
-                                // don't break out of loop as all data need to be collected to be rendered
-                            }
+                            match = true;
+                            // don't break out of loop as all data need to be collected to be rendered
                         }
-                        catch (Exception ex)
-                        {
-                            _filterErrorLabel.Text = ex.Message;
-                            _filterErrorLabel.ColorScheme = Colors.Error;
-                            _filterErrorLabel.Redraw(_filterErrorLabel.Bounds);
-                            return;
-                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _filterErrorLabel.Text = ex.Message;
+                        _filterErrorLabel.ColorScheme = Colors.Error;
+                        _filterErrorLabel.Redraw(_filterErrorLabel.Bounds);
+                        return;
                     }
                     
                     valueList.Add(dataValue);

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -130,7 +130,7 @@ namespace OutGridView.Cmdlet
             var dataTable = TG.CastObjectsToTableView(_psObjects);
             var applicationData = new ApplicationData
             {
-                Title = Title,
+                Title = Title ?? "Out-ConsoleGridView",
                 OutputMode = OutputMode,
                 PassThru = PassThru,
                 DataTable = dataTable


### PR DESCRIPTION
Add filter field that accepts a case insensitive regex.  The `Apply` button needs to be used for it to filter as the `Changed` event for the TextField doesn't appear to fire.  Added a hidden label under the field for any errors.  Couldn't find a way to discover the window background color, so using Blue when not shown, but red on black making it easier to red if there is an error.  Changed the table format a bit with dashes under the headers similar to Format-Table.  

See https://twitter.com/Steve_MSFT/status/1238632637587054592 for an example in action