### PR TITLE
Fix -passthru by maintaining map of filtered index mapped to real index

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -26,6 +26,7 @@ namespace OutGridView.Cmdlet
         private int[] _listViewColumnWidths;
         private int _listViewOffset;
         private Label _filterErrorLabel;
+        private Dictionary<int, int> _indexMap = new Dictionary<int, int>();
 
         internal HashSet<int> SelectedIndexes { get; private set; } = new HashSet<int>();
         public void Start(ApplicationData applicationData)
@@ -214,7 +215,7 @@ namespace OutGridView.Cmdlet
             {
                 if(_listView.Source.IsMarked(i))
                 {
-                    SelectedIndexes.Add(i);
+                    SelectedIndexes.Add(_indexMap[i]);
                 }
             }
         }
@@ -228,6 +229,7 @@ namespace OutGridView.Cmdlet
         private void FilterData(string filter)
         {
             var items = new List<string>();
+            _indexMap.Clear();
             if (string.IsNullOrEmpty(filter))
             {
                 filter = ".*";
@@ -237,8 +239,11 @@ namespace OutGridView.Cmdlet
             _filterErrorLabel.ColorScheme = Colors.Base;
             _filterErrorLabel.Redraw(_filterErrorLabel.Bounds);
 
-            foreach (DataTableRow dataTableRow in _applicationData.DataTable.Data)
+
+            int index = 0;
+            for (int i = 0; i < _applicationData.DataTable.Data.Count; i++)
             {
+                var dataTableRow = _applicationData.DataTable.Data[i];
                 bool match = false;
                 var valueList = new List<string>();
                 foreach (var dataTableColumn in _applicationData.DataTable.DataColumns)
@@ -267,6 +272,8 @@ namespace OutGridView.Cmdlet
                 if (match)
                 {
                     items.Add(GetPaddedString(valueList));
+                    _indexMap.Add(index, i);
+                    index++;
                 }
             }
 

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -240,7 +240,7 @@ namespace OutGridView.Cmdlet
             _filterErrorLabel.Redraw(_filterErrorLabel.Bounds);
 
 
-            int index = 0;
+            int newIndex = 0;
             for (int i = 0; i < _applicationData.DataTable.Data.Count; i++)
             {
                 var dataTableRow = _applicationData.DataTable.Data[i];
@@ -272,8 +272,8 @@ namespace OutGridView.Cmdlet
                 if (match)
                 {
                     items.Add(GetPaddedString(valueList));
-                    _indexMap.Add(index, i);
-                    index++;
+                    _indexMap.Add(newIndex, i);
+                    newIndex++;
                 }
             }
 

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
@@ -9,7 +9,7 @@
 RootModule = 'Microsoft.PowerShell.ConsoleGuiTools.dll'
 
 # Version number of this module.
-ModuleVersion = '0.4.0'
+ModuleVersion = '0.4.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @( 'Core' )
@@ -105,6 +105,10 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '# Release Notes
+
+## v0.4.1
+
+* Fix filter indexing to return correct selected objects
 
 ## v0.4.0
 


### PR DESCRIPTION
After filtering was added, the selected index was no longer accurate.  Fix is to maintain a mapping between the filtered index and the real index that gets updated every time filtering is applied.

Fix https://github.com/PowerShell/GraphicalTools/issues/68