### PR TITLE
Remove -PassThru switch and make it default

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -27,9 +27,8 @@ namespace OutGridView.Cmdlet
             _applicationData = applicationData;
             _gridViewDetails = new GridViewDetails
             {
-                // If we have PassThru, then we want to make them selectable. If we make them selectable,
-                // they have a 8 character addition of a checkbox ("     [ ]") that we have to factor in.
-                ListViewOffset = _applicationData.PassThru ? 8 : 4
+                // Have a 8 character addition of a checkbox ("     [ ]") that we have to factor in.
+                ListViewOffset = 8
             };
 
             AddMenu();
@@ -51,7 +50,7 @@ namespace OutGridView.Cmdlet
 
             // Return results of selection if required.
             HashSet<int> selectedIndexes = new HashSet<int>();
-            if (_cancelled || !_applicationData.PassThru)
+            if (_cancelled)
             {
                 return selectedIndexes;
             }
@@ -88,15 +87,10 @@ namespace OutGridView.Cmdlet
             var menu = new MenuBar(new MenuBarItem []
             {
                 new MenuBarItem("_Actions (F9)", 
-                    _applicationData.PassThru
-                    ? new MenuItem []
+                    new MenuItem []
                     {
                         new MenuItem("_Accept", string.Empty, () => { Application.RequestStop(); }),
                         new MenuItem("_Cancel", string.Empty, () =>{ _cancelled = true; Application.RequestStop(); })
-                    }
-                    : new MenuItem []
-                    {
-                        new MenuItem("_Close", string.Empty, () =>{ Application.RequestStop(); })
                     })
             });
 
@@ -288,7 +282,7 @@ namespace OutGridView.Cmdlet
                 Y = 4,
                 Width = Dim.Fill(2),
                 Height = Dim.Fill(2),
-                AllowsMarking = _applicationData.PassThru
+                AllowsMarking = true
             };
 
             win.Add(_listView);

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDetails.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDetails.cs
@@ -9,8 +9,7 @@ namespace OutGridView.Cmdlet
         public int[] ListViewColumnWidths { get; set; }
 
         // Dictates where the grid should actually start considering
-        // some offset is needed to factor in the checkboxes if using
-        // PassThru.
+        // some offset is needed to factor in the checkboxes
         public int ListViewOffset { get; set; }
 
         // The width that is actually useable on the screen after

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -13,7 +13,7 @@ namespace OutGridView.Cmdlet
 {
     /// Enum for SelectionMode parameter.
     /// </summary>
-    [Cmdlet(VerbsData.Out, "ConsoleGridView", DefaultParameterSetName = "PassThru")]
+    [Cmdlet(VerbsData.Out, "ConsoleGridView")]
     [Alias("ocgv")]
     public class OutConsoleGridViewCmdletCommand : PSCmdlet, IDisposable
     {
@@ -46,20 +46,8 @@ namespace OutGridView.Cmdlet
         /// Get or sets a value indicating whether the selected items should be written to the pipeline
         /// and if it should be possible to select multiple or single list items.
         /// </summary>
-        [Parameter(ParameterSetName = "OutputMode")]
+        [Parameter()]
         public OutputModeOption OutputMode { set; get; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the selected items should be written to the pipeline.
-        /// Setting this to true is the same as setting the OutputMode to Multiple.
-        /// </summary>
-        [Parameter(ParameterSetName = "PassThru")]
-        public SwitchParameter PassThru
-        {
-            set { this.OutputMode = value.IsPresent ? OutputModeOption.Multiple : OutputModeOption.None; }
-
-            get { return OutputMode == OutputModeOption.Multiple ? new SwitchParameter(true) : new SwitchParameter(false); }
-        }
 
         #endregion Input Parameters
 
@@ -142,18 +130,11 @@ namespace OutGridView.Cmdlet
             {
                 Title = Title ?? "Out-ConsoleGridView",
                 OutputMode = OutputMode,
-                PassThru = PassThru,
                 DataTable = dataTable
             };
 
 
             var selectedIndexes = _consoleGui.Start(applicationData);
-
-            // Don't write anything out to the pipeline if PassThru wasn't specified.
-            if (!PassThru.IsPresent)
-            {
-                return;
-            }
 
             foreach (int idx in selectedIndexes)
             {


### PR DESCRIPTION
For `Out-ConsoleGridView`, the GUI is always blocking (unlike `Out-GridView`) so it doesn't make sense to have a `-PassThru` and just make it always pass through.

Fix https://github.com/PowerShell/GraphicalTools/issues/71