### PR TITLE
Update ocgv to use pre-release of Terminal.Gui 0.90

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,35 @@ Get-Process | Out-ConsoleGridView
 > NOTE: If you change the code and rebuild the project, you'll need to launch a
 > _new_ PowerShell process since the dll is already loaded and can't be unloaded.
 
+### Debugging in Visual Studio Code
+
+
+```powershell
+PS C:\path\to\GraphicalTools> code .
+```
+
+Build by hitting `Ctrl-Shift-b` in VS Code.
+
+To debug:
+
+In a Powershell session in the `c:\path\to\GraphicalTools` directory, run `pwsh` (thus nesting powershell).
+
+Then do the folowing:
+
+```powershell
+Import-Module .\module\Microsoft.PowerShell.ConsoleGuiTools
+$pid
+```
+
+This will import the latest built DLL and output the process ID you'll need for debugging. Copy this ID to the clipboard.
+
+In VScode, set your breakpoints, etc... Then hit `F5`. In the VScode search box, paste the value printed by `$pid`. You'll see something like `pwsh.exe 18328`. Click that and the debug session will start.
+
+In the Powershell session run your commands; breakpoints will be hit, etc...
+
+When done, run `exit` to exit the nested PowerShell and run `pwsh` again. This unloads the DLL. Repeat.
+
+
 ## Contributions Welcome!
 
 We would love to incorporate community contributions into this project.  If you would like to

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -48,6 +48,7 @@ namespace OutGridView.Cmdlet
 
             // Run the GUI.
             Application.Run();
+            Application.Shutdown();
 
             // Return results of selection if required.
             HashSet<int> selectedIndexes = new HashSet<int>();

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using OutGridView.Models;
 using Terminal.Gui;
 
@@ -163,6 +164,11 @@ namespace OutGridView.Cmdlet
                     // Add a space between columns
                     builder.Append(' ');
                 }
+
+                // Replace any newlines with encoded newline (`n)
+                // Note we can't use Environment.Newline because we don't know that the
+                // Command honors that.
+                strings[i] = strings[i].Replace("\n", "`n");
 
                 // If the string won't fit in the column, append an ellipsis.
                 if (strings[i].Length > colWidths[i])

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -193,11 +193,11 @@ namespace OutGridView.Cmdlet
                 Width = Dim.Fill() - filterLabel.Text.Length
             };
 
-            _filterField.Changed += (object sender, ustring e) =>
+            _filterField.TextChanged += (str) =>
             {
-                // NOTE: `ustring e` seems to contain the text _before_ the added character...
-                // so we convert the `sender` into a TextField and grab the text from that.
-                string filterText = (sender as TextField)?.Text?.ToString();
+                // NOTE: `str` seems to contain the text _before_ the added character...
+                // so we go direct to Text
+                string filterText = _filterField.Text?.ToString();
                 try
                 {
                     filterErrorLabel.Text = " ";

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -164,10 +164,10 @@ namespace OutGridView.Cmdlet
                     builder.Append(' ');
                 }
 
-                // Replace any newlines with encoded newline (`n)
+                // Replace any newlines with encoded newline/linefeed (`n or `r)
                 // Note we can't use Environment.Newline because we don't know that the
                 // Command honors that.
-                strings[i] = strings[i].Replace("\r\n", "`r`n");
+                strings[i] = strings[i].Replace("\r", "`r");
                 strings[i] = strings[i].Replace("\n", "`n");
 
                 // If the string won't fit in the column, append an ellipsis.

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Text.RegularExpressions;
 using OutGridView.Models;
 using Terminal.Gui;
 

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -106,7 +106,7 @@ namespace OutGridView.Cmdlet
                                 Accept();
                             }
                             else if (Application.Top.MostFocused == _filterField){
-                                Application.Top.SetFocus(_listView);
+                                _listView.SetFocus();
                             }
                         }),
                         new StatusItem(Key.Esc, "~ESC~ Close", () => Close())

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -167,6 +167,7 @@ namespace OutGridView.Cmdlet
                 // Replace any newlines with encoded newline (`n)
                 // Note we can't use Environment.Newline because we don't know that the
                 // Command honors that.
+                strings[i] = strings[i].Replace("\r\n", "`r`n");
                 strings[i] = strings[i].Replace("\n", "`n");
 
                 // If the string won't fit in the column, append an ellipsis.

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDataSource.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDataSource.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using NStack;
 using Terminal.Gui;
@@ -30,6 +31,11 @@ namespace OutGridView.Cmdlet
         public void SetMark(int item, bool value)
         {
             GridViewRowList[item].IsMarked = value;
+        }
+        
+        public IList ToList()
+        {
+            return GridViewRowList;
         }
 
         // A slightly adapted method from gui.cs: https://github.com/migueldeicaza/gui.cs/blob/fc1faba7452ccbdf49028ac49f0c9f0f42bbae91/Terminal.Gui/Views/ListView.cs#L433-L461

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.csproj
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.csproj
@@ -6,12 +6,11 @@
 
     <ItemGroup>
         <PackageReference Include="Nstack.Core" Version="0.14.0" />
-        <!-- <PackageReference Include="Terminal.Gui" Version="0.81.0" /> -->
+        <PackageReference Include="Terminal.Gui" Version="0.89.3" />
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include ="../../../gui.cs/Terminal.Gui/Terminal.Gui.csproj" />
         <ProjectReference Include ="../OutGridView.Models/OutGridView.Models.csproj" />
     </ItemGroup>
 

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.csproj
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.csproj
@@ -6,11 +6,12 @@
 
     <ItemGroup>
         <PackageReference Include="Nstack.Core" Version="0.14.0" />
-        <PackageReference Include="Terminal.Gui" Version="0.81.0" />
+        <!-- <PackageReference Include="Terminal.Gui" Version="0.81.0" /> -->
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.2.1" />
     </ItemGroup>
 
     <ItemGroup>
+        <ProjectReference Include ="../../../gui.cs/Terminal.Gui/Terminal.Gui.csproj" />
         <ProjectReference Include ="../OutGridView.Models/OutGridView.Models.csproj" />
     </ItemGroup>
 

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Properties/launchSettings.json
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "Microsoft.PowerShell.ConsoleGuiTools": {
+      "commandName": "Executable"
+    }
+  }
+}


### PR DESCRIPTION
This PR updates `Out-ConsoleGridView` to use the massively updated Terminal.Gui 0.90.

0.90 is supposed to to be the "feature complete" release of `Terminal.Gui` and has undergone significant improvements. 0.90 is not yet released as one of the release criteria is to ensure `ocgv` worked well.

So this PR uses the Terminal.Gui `0.89.4` nuget package which is just a tad behind the Terminal.Gui `master`. 

Folks should check this PR out locally and test test test. If no big issues are found then it can be merged.