### PR TITLE
fix off by one error with ellipsis

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewHelpers.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewHelpers.cs
@@ -58,7 +58,7 @@ namespace OutGridView.Cmdlet
                 // If the string won't fit in the column, append an ellipsis.
                 if (strings[i].Length > listViewColumnWidths[i])
                 {
-                    builder.Append(strings[i].Substring(0, listViewColumnWidths[i] - 4));
+                    builder.Append(strings[i], 0, listViewColumnWidths[i] - 3);
                     builder.Append("...");
                 }
                 else

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
@@ -9,7 +9,7 @@
 RootModule = 'Microsoft.PowerShell.ConsoleGuiTools.dll'
 
 # Version number of this module.
-ModuleVersion = '0.6.0'
+ModuleVersion = '0.6.1'
 
 # Supported PSEditions
 CompatiblePSEditions = @( 'Core' )
@@ -105,6 +105,10 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = '# Release Notes
+
+## v0.6.1
+
+Fix off-by-one error with ellipsis so columns should be better aligned.
 
 ## v0.6.0
 


### PR DESCRIPTION
fixes https://github.com/PowerShell/GraphicalTools/issues/104

I'm not sure why this was 4 before... maybe a typo... or maybe they thought the Substring was _inclusive_.... but anyway, this aligns things properly.

![image](https://user-images.githubusercontent.com/2644648/94509026-2a517300-01c8-11eb-8a54-115728038aad.png)

I'd love it if @tig could review/give my PR a try