### PR TITLE
Make Out-ConsoleGridView fail gracefully in remote session

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -320,11 +320,14 @@ namespace OutGridView.Cmdlet
 
         public void Dispose()
         {
-            // By emitting this, we fix an issue where arrow keys don't work in the console
-            // because .NET requires application mode to support Arrow key escape sequences
-            // Esc[?1h - Set cursor key to application mode
-            // See http://ascii-table.com/ansi-escape-sequences-vt-100.php
-            Console.Write("\u001b[?1h");
+            if (Console.IsInputRedirected == false)
+            {
+                // By emitting this, we fix an issue where arrow keys don't work in the console
+                // because .NET requires application mode to support Arrow key escape sequences
+                // Esc[?1h - Set cursor key to application mode
+                // See http://ascii-table.com/ansi-escape-sequences-vt-100.php
+                Console.Write("\u001b[?1h");
+            }
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -320,7 +320,7 @@ namespace OutGridView.Cmdlet
 
         public void Dispose()
         {
-            if (Console.IsInputRedirected == false)
+            if (!Console.IsInputRedirected)
             {
                 // By emitting this, we fix an issue where arrow keys don't work in the console
                 // because .NET requires application mode to support Arrow key escape sequences

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
+using System.Management.Automation.Remoting;
 using OutGridView.Models;
 
 namespace OutGridView.Cmdlet
@@ -57,6 +58,17 @@ namespace OutGridView.Cmdlet
         // This method gets called once for each cmdlet in the pipeline when the pipeline starts executing
         protected override void BeginProcessing()
         {
+            if (GetVariableValue("PSSenderInfo") is PSSenderInfo)
+            {
+                ErrorRecord error = new ErrorRecord(
+                    new PSNotSupportedException("Not supported in remote sessions."),
+                    EnvironmentNotSupportedForGridView,
+                    ErrorCategory.NotImplemented,
+                    null);
+
+                ThrowTerminatingError(error);
+            }
+
             if (Console.IsInputRedirected)
             {
                 ErrorRecord error = new ErrorRecord(
@@ -151,7 +163,10 @@ namespace OutGridView.Cmdlet
 
         public void Dispose()
         {
-            _consoleGui.Dispose();
+            if (GetVariableValue("PSSenderInfo") is null)
+            {
+                _consoleGui.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -6,7 +6,6 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
-using System.Management.Automation.Remoting;
 using OutGridView.Models;
 
 namespace OutGridView.Cmdlet
@@ -58,17 +57,6 @@ namespace OutGridView.Cmdlet
         // This method gets called once for each cmdlet in the pipeline when the pipeline starts executing
         protected override void BeginProcessing()
         {
-            if (GetVariableValue("PSSenderInfo") is PSSenderInfo)
-            {
-                ErrorRecord error = new ErrorRecord(
-                    new PSNotSupportedException("Not supported in remote sessions."),
-                    EnvironmentNotSupportedForGridView,
-                    ErrorCategory.NotImplemented,
-                    null);
-
-                ThrowTerminatingError(error);
-            }
-
             if (Console.IsInputRedirected)
             {
                 ErrorRecord error = new ErrorRecord(
@@ -163,10 +151,7 @@ namespace OutGridView.Cmdlet
 
         public void Dispose()
         {
-            if (GetVariableValue("PSSenderInfo") is null)
-            {
-                _consoleGui.Dispose();
-            }
+            _consoleGui.Dispose();
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -151,7 +151,11 @@ namespace OutGridView.Cmdlet
 
         public void Dispose()
         {
-            _consoleGui.Dispose();
+            // Only call Dispose when not in a remote session
+            if (Console.IsInputRedirected == false)
+            {
+                _consoleGui.Dispose();
+            }
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -151,11 +151,7 @@ namespace OutGridView.Cmdlet
 
         public void Dispose()
         {
-            // Only call Dispose when not in a remote session
-            if (Console.IsInputRedirected == false)
-            {
-                _consoleGui.Dispose();
-            }
+            _consoleGui.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes PowerShell/GraphicalTools#123

Attempting to use `Out-ConsoleGridView` in remote sessions will result in an unexpected error and crashing out of the remote session. This PR will make sure OCGV instead throws a terminating PSNotSupportedException without exiting the remote session.

**Behaviour before PR:**
```
PS C:\Users\admin> $session = New-PSSession -HostName computer -UserName admin
admin@computer's password:
PS C:\Users\admin> Enter-PSSession -Session $session
[admin@computer]: PS /home/admin> Get-Process | Out-ConsoleGridView
There is an error processing data from the background process. Error reported: 'exadecimal value 0x1B, is an invalid character. Line 1, position 1..
PS C:\Users\admin>
```

**Behaviour after PR:**
```
PS C:\Users\admin> $session = New-PSSession -HostName computer -UserName admin
admin@computer's password:
PS C:\Users\admin> Enter-PSSession -Session $session
[admin@computer]: PS /home/admin> Get-Process | Out-ConsoleGridView

Error: Not supported in this environment (when input is redirected).
[admin@computer]: PS /home/admin>
```
