### PR TITLE
Fixes #178 Add Show-Object

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
@@ -69,7 +69,7 @@ NestedModules = @()
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = @( 'Out-ConsoleGridView' )
+CmdletsToExport = @( 'Out-ConsoleGridView', 'Out-ShowObject' )
 
 # Variables to export from this module
 VariablesToExport = '*'

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectCmdletCommand.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Internal;
+using OutGridView.Models;
+
+namespace OutGridView.Cmdlet
+{
+    [Cmdlet(VerbsData.Out, "ShowObject")]
+    public class ShowObjectCmdletCommand : PSCmdlet, IDisposable
+    {
+        #region Properties
+        
+        private const string DataNotQualifiedForGridView = nameof(DataNotQualifiedForGridView);
+        private const string EnvironmentNotSupportedForGridView = nameof(EnvironmentNotSupportedForGridView);
+
+        private List<PSObject> _psObjects = new List<PSObject>();
+
+        #endregion Properties
+
+        #region Input Parameters
+
+        /// <summary>
+        /// This parameter specifies the current pipeline object.
+        /// </summary>
+        [Parameter(ValueFromPipeline = true, HelpMessage = "Specifies the input pipeline object")]
+        public PSObject InputObject { get; set; } = AutomationNull.Value;
+
+        #endregion Input Parameters
+
+        // This method gets called once for each cmdlet in the pipeline when the pipeline starts executing
+        protected override void BeginProcessing()
+        {
+            if (Console.IsInputRedirected)
+            {
+                ErrorRecord error = new ErrorRecord(
+                    new PSNotSupportedException("Not supported in this environment (when input is redirected)."),
+                    EnvironmentNotSupportedForGridView,
+                    ErrorCategory.NotImplemented,
+                    null);
+
+                ThrowTerminatingError(error);
+            }
+        }
+
+        // This method will be called for each input received from the pipeline to this cmdlet; if no input is received, this method is not called
+        protected override void ProcessRecord()
+        {
+            if (InputObject == null || InputObject == AutomationNull.Value)
+            {
+                return;
+            }
+
+            if (InputObject.BaseObject is IDictionary dictionary)
+            {
+                // Dictionaries should be enumerated through because the pipeline does not enumerate through them.
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    ProcessObject(PSObject.AsPSObject(entry));
+                }
+            }
+            else
+            {
+                ProcessObject(InputObject);
+            }
+        }
+
+        private void ProcessObject(PSObject input)
+        {
+
+            object baseObject = input.BaseObject;
+
+            // Throw a terminating error for types that are not supported.
+            if (baseObject is ScriptBlock ||
+                baseObject is SwitchParameter ||
+                baseObject is PSReference ||
+                baseObject is PSObject)
+            {
+                ErrorRecord error = new ErrorRecord(
+                    new FormatException("Invalid data type for Out-GridView"),
+                    DataNotQualifiedForGridView,
+                    ErrorCategory.InvalidType,
+                    null);
+
+                ThrowTerminatingError(error);
+            }
+
+            _psObjects.Add(input);
+        }
+
+        // This method will be called once at the end of pipeline execution; if no input is received, this method is not called
+        protected override void EndProcessing()
+        {
+            base.EndProcessing();
+
+            //Return if no objects
+            if (_psObjects.Count == 0)
+            {
+                return;
+            }
+            
+            ShowObjectView.Run(_psObjects);
+        }
+
+        public void Dispose()
+        {
+            
+        }
+    }
+}

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectView.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectView.cs
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Terminal.Gui;
+using Terminal.Gui.Trees;
+using System.Management.Automation;
+using System.Management.Automation.Internal;
+using System.Linq;
+
+namespace OutGridView.Cmdlet
+{
+    internal class ShowObjectView : Window, ITreeBuilder<object>
+    {
+        private readonly TreeView<object> tree;
+
+        public bool SupportsCanExpand => true;
+
+        public ShowObjectView(List<object> rootObjects)
+        {
+            Width = Dim.Fill();
+            Height = Dim.Fill();
+
+            tree = new TreeView<object>
+            {
+                Width = Dim.Fill(),
+                Height = Dim.Fill(),
+            };
+            tree.TreeBuilder = this;
+
+            if (rootObjects.Count > 0)
+            {
+                tree.AddObjects(rootObjects);
+            }
+            else
+            {
+                tree.AddObject("No Objects");
+            }
+
+            Add(tree);
+        }
+
+        
+
+        public bool CanExpand(object toExpand)
+        {
+            if (toExpand is CachedMemberResult p)
+            {
+                return IsBasicType(p?.Value);
+            }
+
+            // Any complex object type can be expanded to reveal properties
+            return IsBasicType(toExpand);
+        }
+
+        private bool IsBasicType(object? value)
+        {
+            return value != null && value is not string && !value.GetType().IsValueType;
+        }
+
+        public IEnumerable<object> GetChildren(object forObject)
+        {
+            if(forObject is CachedMemberResult p) 
+            {
+                return GetChildren(p.Value);
+            }
+
+            List<object> children = new List<object>();
+            
+            // Vanilla object
+            foreach (var prop in forObject.GetType().GetProperties())
+            {
+                children.Add(new CachedMemberResult(forObject, prop));
+            }
+            foreach (var field in forObject.GetType().GetFields())
+            {
+                children.Add(new CachedMemberResult(forObject, field));
+            }
+
+            return children;
+        }
+
+        internal static void Run(List<PSObject> objects)
+        {
+
+            Application.Init();
+            Window window = null;
+            
+            try
+            {                
+                window = new ShowObjectView(objects.Select(p=>p.BaseObject).ToList());
+                Application.Run(window);
+            }
+            finally{
+                Application.Shutdown();
+                window?.Dispose();
+            }
+        }
+
+        class CachedMemberResult
+        {
+            public MemberInfo Member;
+            public object Value;
+            public object Parent;
+            private string representation;
+
+            public CachedMemberResult(object parent, MemberInfo mem)
+            {
+                Parent = parent;
+                Member = mem;
+
+                try
+                {
+                    if (mem is PropertyInfo p)
+                    {
+                        Value = p.GetValue(parent);
+                    }
+                    else if (mem is FieldInfo f)
+                    {
+                        Value = f.GetValue(parent);
+                    }
+                    else
+                        throw new NotSupportedException($"Unknown {nameof(MemberInfo)} Type");
+
+                    representation = Value?.ToString() ?? "Null";
+
+                }
+                catch (Exception)
+                {
+                    Value = representation = "Unavailable";
+                }
+            }
+
+            public override string ToString()
+            {
+                return Member.Name + ":" + representation;
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
Adds the `out-ShowObject` command which presents the passed objects in a tree.  Below each object passed appear its public fields/properties.  

- Value, Null, String (or where an Exception was grenerated querying property) appear as leaf elements
- All other properties can be expanded as branches

![out-showobject](https://user-images.githubusercontent.com/31306100/210569074-c8380db1-9a5e-4f49-a509-221bc180c52b.gif)

<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
This is my first time working with powershell commandlets so please be gentle.

I thought I would look into implementing #178 .  Let me know if this is not what you were expecting.  If its not wildly out.

I am happy to look into adding whatever else is required (e.g. filtering / highlighting etc).

