### PR TITLE
Marked are now at top; simplified code; fixed margin

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -338,7 +338,6 @@ namespace OutGridView.Cmdlet
                     filterErrorLabel.Text = ex.Message;
                     filterErrorLabel.ColorScheme = Colors.Error;
                     filterErrorLabel.Redraw(filterErrorLabel.Bounds);
-                    //_listView.Source = _inputSource;
                 }
             };
 

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -15,7 +15,7 @@ namespace OutGridView.Cmdlet
     {
         private const string FILTER_LABEL = "Filter";
         // This adjusts the left margin of all controls
-        private const int MARGIN_LEFT = 2;
+        private const int MARGIN_LEFT = 1;
         // Width of Terminal.Gui ListView selection/check UI elements (old == 4, new == 2)
         private const int CHECK_WIDTH = 2;
         private bool _cancelled;
@@ -302,7 +302,7 @@ namespace OutGridView.Cmdlet
                 X = Pos.Right(_filterLabel) + 1,
                 Y = Pos.Top(_filterLabel),
                 CanFocus = true,
-                Width = Dim.Fill() - _filterLabel.Text.Length
+                Width = Dim.Fill() - 1
             };
 
             // TextField captures Ctrl-A (select all text) and Ctrl-D (delete backwards)
@@ -338,7 +338,7 @@ namespace OutGridView.Cmdlet
                     filterErrorLabel.Text = ex.Message;
                     filterErrorLabel.ColorScheme = Colors.Error;
                     filterErrorLabel.Redraw(filterErrorLabel.Bounds);
-                    _listView.Source = _inputSource;
+                    //_listView.Source = _inputSource;
                 }
             };
 
@@ -403,7 +403,7 @@ namespace OutGridView.Cmdlet
             {
                 _listView.Y = 1; // 1 for space, 1 for header, 1 for header underline
             }
-            _listView.Width = Dim.Fill(2);
+            _listView.Width = Dim.Fill(1);
             _listView.Height = Dim.Fill();
             _listView.AllowsMarking = _applicationData.OutputMode != OutputModeOption.None;
             _listView.AllowsMultipleSelection = _applicationData.OutputMode == OutputModeOption.Multiple;

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewHelpers.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewHelpers.cs
@@ -14,23 +14,20 @@ namespace OutGridView.Cmdlet
 {
     internal class GridViewHelpers
     {
-        public static List<GridViewRow> FilterData(List<GridViewRow> list, string filter)
+        // Add all items already selected plus any that match the filter
+        // The selected items should be at the top of the list, in their original order
+        public static List<GridViewRow> FilterData(List<GridViewRow> listToFilter, string filter)
         {
-            var items = new List<GridViewRow>();
+            var filteredList = new List<GridViewRow>();
             if (string.IsNullOrEmpty(filter))
             {
-                filter = ".*";
+                return listToFilter;
             }
 
-            foreach (GridViewRow gvr in list)
-            {
-                if (gvr.IsMarked || Regex.IsMatch(gvr.DisplayString, filter, RegexOptions.IgnoreCase))
-                {
-                    items.Add(gvr);
-                }
-            }
+            filteredList.AddRange(listToFilter.Where(gvr => gvr.IsMarked));
+            filteredList.AddRange(listToFilter.Where(gvr => !gvr.IsMarked && Regex.IsMatch(gvr.DisplayString, filter, RegexOptions.IgnoreCase)));
 
-            return items;
+            return filteredList;
         }
 
         public static string GetPaddedString(List<string> strings, int offset, int[] listViewColumnWidths)


### PR DESCRIPTION
# PR Summary

In #174, my fix didn't put the marked items at the top of the filtered list. @MrFly22 duly noted this.

The fix needed me to iterate of the input list twice (I could have added complexity to make this more efficient but decided until someone complains about perf...). There's now two simple Linq statements that do the trick

I noticed a related bug in my testing. When the filter has an invalid regex, we were just setting the ListView to the source list. In addition, the logic around what an empty filter string means was confused. I fixed these issues.

Finally, the extra space at the end of the filter edit and the wasteful margins around the listview have been driving me nuts. 

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
