### PR TITLE
Enable, fix, and enforce recommended .NET analyzers and format files

### DIFF
--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -7,13 +7,14 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using NStack;
+
 using OutGridView.Models;
+
 using Terminal.Gui;
 
 namespace OutGridView.Cmdlet
 {
-    internal class ConsoleGui : IDisposable
+    internal sealed class ConsoleGui : IDisposable
     {
         private const string FILTER_LABEL = "Filter";
         // This adjusts the left margin of all controls
@@ -154,7 +155,7 @@ namespace OutGridView.Cmdlet
             _inputSource.GridViewRowList[a.Row.OriginalIndex].IsMarked = a.Row.IsMarked;
         }
 
-        private void Accept()
+        private static void Accept()
         {
             Application.RequestStop();
         }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ConsoleGui.cs
@@ -138,19 +138,20 @@ namespace OutGridView.Cmdlet
             // The ListView is always filled with a (filtered) copy of _inputSource.
             // We listen for `MarkChanged` events on this filtered list and apply those changes up to _inputSource.
 
-            if (_listViewSource != null) {
+            if (_listViewSource != null)
+            {
                 _listViewSource.MarkChanged -= ListViewSource_MarkChanged;
                 _listViewSource = null;
             }
 
             _listViewSource = new GridViewDataSource(GridViewHelpers.FilterData(_inputSource.GridViewRowList, _applicationData.Filter ?? string.Empty));
-            _listViewSource.MarkChanged +=  ListViewSource_MarkChanged;
+            _listViewSource.MarkChanged += ListViewSource_MarkChanged;
             _listView.Source = _listViewSource;
         }
 
-        private void ListViewSource_MarkChanged (object s, GridViewDataSource.RowMarkedEventArgs a)
+        private void ListViewSource_MarkChanged(object s, GridViewDataSource.RowMarkedEventArgs a)
         {
-                _inputSource.GridViewRowList[a.Row.OriginalIndex].IsMarked = a.Row.IsMarked;
+            _inputSource.GridViewRowList[a.Row.OriginalIndex].IsMarked = a.Row.IsMarked;
         }
 
         private void Accept()
@@ -243,7 +244,7 @@ namespace OutGridView.Cmdlet
             if (_applicationData.Verbose || _applicationData.Debug)
             {
                 statusItems.Add(new StatusItem(Key.Null, $" v{_applicationData.ModuleVersion}", null));
-                statusItems.Add(new StatusItem(Key.Null, 
+                statusItems.Add(new StatusItem(Key.Null,
                 $"{Application.Driver} v{FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(Application)).Location).ProductVersion}", null));
             }
 
@@ -355,7 +356,7 @@ namespace OutGridView.Cmdlet
             win.Add(_filterLabel, _filterField, filterErrorLabel);
 
             _filterField.Text = _applicationData.Filter ?? string.Empty;
-            _filterField.CursorPosition = _filterField.Text.Length;            
+            _filterField.CursorPosition = _filterField.Text.Length;
         }
 
         private void AddHeaders(Window win, List<string> gridHeaders)
@@ -417,7 +418,7 @@ namespace OutGridView.Cmdlet
             _listView.Height = Dim.Fill();
             _listView.AllowsMarking = _applicationData.OutputMode != OutputModeOption.None;
             _listView.AllowsMultipleSelection = _applicationData.OutputMode == OutputModeOption.Multiple;
-            _listView.AddKeyBinding (Key.Space, Command.ToggleChecked, Command.LineDown);
+            _listView.AddKeyBinding(Key.Space, Command.ToggleChecked, Command.LineDown);
 
             win.Add(_listView);
         }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDataSource.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDataSource.cs
@@ -34,16 +34,18 @@ namespace OutGridView.Cmdlet
         {
             var oldValue = GridViewRowList[item].IsMarked;
             GridViewRowList[item].IsMarked = value;
-            var args = new RowMarkedEventArgs() { 
+            var args = new RowMarkedEventArgs()
+            {
                 Row = GridViewRowList[item],
                 OldValue = oldValue
             };
             MarkChanged?.Invoke(this, args);
         }
 
-        public class RowMarkedEventArgs : EventArgs {
-            public GridViewRow Row { get; set;}
-            public bool OldValue { get ; set;}
+        public class RowMarkedEventArgs : EventArgs
+        {
+            public GridViewRow Row { get; set; }
+            public bool OldValue { get; set; }
 
         }
 
@@ -53,7 +55,7 @@ namespace OutGridView.Cmdlet
         {
             return GridViewRowList;
         }
-        
+
         // A slightly adapted method from gui.cs: https://github.com/migueldeicaza/gui.cs/blob/fc1faba7452ccbdf49028ac49f0c9f0f42bbae91/Terminal.Gui/Views/ListView.cs#L433-L461
         private void RenderUstr(ConsoleDriver driver, ustring ustr, int col, int line, int width)
         {

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDataSource.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDataSource.cs
@@ -4,12 +4,14 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+
 using NStack;
+
 using Terminal.Gui;
 
 namespace OutGridView.Cmdlet
 {
-    internal class GridViewDataSource : IListDataSource
+    internal sealed class GridViewDataSource : IListDataSource
     {
         public List<GridViewRow> GridViewRowList { get; set; }
 
@@ -42,7 +44,7 @@ namespace OutGridView.Cmdlet
             MarkChanged?.Invoke(this, args);
         }
 
-        public class RowMarkedEventArgs : EventArgs
+        public sealed class RowMarkedEventArgs : EventArgs
         {
             public GridViewRow Row { get; set; }
             public bool OldValue { get; set; }
@@ -57,7 +59,7 @@ namespace OutGridView.Cmdlet
         }
 
         // A slightly adapted method from gui.cs: https://github.com/migueldeicaza/gui.cs/blob/fc1faba7452ccbdf49028ac49f0c9f0f42bbae91/Terminal.Gui/Views/ListView.cs#L433-L461
-        private void RenderUstr(ConsoleDriver driver, ustring ustr, int col, int line, int width)
+        private static void RenderUstr(ConsoleDriver driver, ustring ustr, int col, int line, int width)
         {
             int used = 0;
             int index = 0;

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDetails.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewDetails.cs
@@ -3,7 +3,7 @@
 
 namespace OutGridView.Cmdlet
 {
-    internal class GridViewDetails
+    internal sealed class GridViewDetails
     {
         // Contains the width of each column in the grid view.
         public int[] ListViewColumnWidths { get; set; }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewHelpers.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/GridViewHelpers.cs
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
-using NStack;
-using OutGridView.Models;
-using Terminal.Gui;
 
 namespace OutGridView.Cmdlet
 {
-    internal class GridViewHelpers
+    internal sealed class GridViewHelpers
     {
         // Add all items already selected plus any that match the filter
         // The selected items should be at the top of the list, in their original order

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.csproj
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.csproj
@@ -27,4 +27,10 @@
     <ItemGroup>
         <None Update="Microsoft.PowerShell.ConsoleGuiTools.psd1" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
+
+    <PropertyGroup>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <AnalysisMode>Recommended</AnalysisMode>
+    </PropertyGroup>
 </Project>

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
+
 using OutGridView.Models;
 
 namespace OutGridView.Cmdlet
@@ -180,6 +181,7 @@ namespace OutGridView.Cmdlet
         public void Dispose()
         {
             _consoleGui.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/OutConsoleGridviewCmdletCommand.cs
@@ -49,7 +49,7 @@ namespace OutGridView.Cmdlet
         /// <summary>
         /// gets or sets the initial value for the filter in the GUI
         /// </summary>
-        [Parameter(HelpMessage = "Pre-populates the Filter edit box, allowing filtering to be specified on the command line. The filter uses regular expressions." )]
+        [Parameter(HelpMessage = "Pre-populates the Filter edit box, allowing filtering to be specified on the command line. The filter uses regular expressions.")]
         public string Filter { set; get; }
 
         /// <summary>

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectTreeCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectTreeCmdletCommand.cs
@@ -15,7 +15,7 @@ namespace OutGridView.Cmdlet
     public class ShowObjectTreeCmdletCommand : PSCmdlet, IDisposable
     {
         #region Properties
-        
+
         private const string DataNotQualifiedForShowObjectTree = nameof(DataNotQualifiedForShowObjectTree);
         private const string EnvironmentNotSupportedForShowObjectTree = nameof(EnvironmentNotSupportedForShowObjectTree);
 
@@ -41,7 +41,7 @@ namespace OutGridView.Cmdlet
         /// <summary>
         /// gets or sets the initial value for the filter in the GUI
         /// </summary>
-        [Parameter(HelpMessage = "Pre-populates the Filter edit box, allowing filtering to be specified on the command line. The filter uses regular expressions." )]
+        [Parameter(HelpMessage = "Pre-populates the Filter edit box, allowing filtering to be specified on the command line. The filter uses regular expressions.")]
         public string Filter { set; get; }
 
         /// <summary>
@@ -143,13 +143,13 @@ namespace OutGridView.Cmdlet
                 Debug = Debug,
                 ModuleVersion = MyInvocation.MyCommand.Version.ToString()
             };
-            
+
             ShowObjectView.Run(_psObjects, applicationData);
         }
 
         public void Dispose()
         {
-            
+
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectTreeCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectTreeCmdletCommand.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
+
 using OutGridView.Models;
 
 namespace OutGridView.Cmdlet
@@ -149,7 +150,7 @@ namespace OutGridView.Cmdlet
 
         public void Dispose()
         {
-
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectView.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectView.cs
@@ -2,22 +2,23 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Management.Automation;
 using System.Reflection;
+using System.Text.RegularExpressions;
+
+using OutGridView.Models;
+
 using Terminal.Gui;
 using Terminal.Gui.Trees;
-using System.Management.Automation;
-using System.Management.Automation.Internal;
-using System.Linq;
-using System.Diagnostics;
-using System.Collections;
-using OutGridView.Models;
-using System.Text.RegularExpressions;
-using System.IO;
 
 namespace OutGridView.Cmdlet
 {
-    internal class ShowObjectView : Window, ITreeBuilder<object>
+    internal sealed class ShowObjectView : Window, ITreeBuilder<object>
     {
         private readonly TreeView<object> tree;
         private readonly RegexTreeViewTextFilter filter;
@@ -133,7 +134,7 @@ namespace OutGridView.Cmdlet
         }
         private void SetRegexError(string error)
         {
-            if (string.Equals(error, filterErrorLabel.Text.ToString()))
+            if (string.Equals(error, filterErrorLabel.Text.ToString(), StringComparison.Ordinal))
             {
                 return;
             }
@@ -197,7 +198,7 @@ namespace OutGridView.Cmdlet
             return IsBasicType(toExpand);
         }
 
-        private bool IsBasicType(object value)
+        private static bool IsBasicType(object value)
         {
             return value != null && value is not string && !value.GetType().IsValueType;
         }
@@ -245,7 +246,7 @@ namespace OutGridView.Cmdlet
             return children;
         }
 
-        private IEnumerable<object> GetExtraChildren(object forObject)
+        private static IEnumerable<object> GetExtraChildren(object forObject)
         {
             if (forObject is DirectoryInfo dir)
             {
@@ -277,7 +278,7 @@ namespace OutGridView.Cmdlet
             }
         }
 
-        class CachedMemberResultElement
+        sealed class CachedMemberResultElement
         {
             public int Index;
             public object Value;
@@ -304,7 +305,7 @@ namespace OutGridView.Cmdlet
             }
         }
 
-        class CachedMemberResult
+        sealed class CachedMemberResult
         {
             public MemberInfo Member;
             public object Value;
@@ -402,7 +403,7 @@ namespace OutGridView.Cmdlet
                 return Member.Name + ": " + representation;
             }
         }
-        private class RegexTreeViewTextFilter : ITreeViewFilter<object>
+        private sealed class RegexTreeViewTextFilter : ITreeViewFilter<object>
         {
             private readonly ShowObjectView parent;
             readonly TreeView<object> _forTree;

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectView.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectView.cs
@@ -33,16 +33,16 @@ namespace OutGridView.Cmdlet
             Width = Dim.Fill();
             Height = Dim.Fill(1);
             Modal = false;
-            
 
-            if(applicationData.MinUI)
+
+            if (applicationData.MinUI)
             {
                 Border.BorderStyle = BorderStyle.None;
                 Title = string.Empty;
                 X = -1;
                 Height = Dim.Fill();
             }
-            
+
             tree = new TreeView<object>
             {
                 Y = applicationData.MinUI ? 0 : 2,
@@ -68,31 +68,34 @@ namespace OutGridView.Cmdlet
                 tree.AddObject("No Objects");
             }
             statusBar = new StatusBar();
-            
+
             string elementDescription = "objects";
 
-            var types = rootObjects.Select(o=>o.GetType()).Distinct().ToArray();
-            if(types.Length == 1)
+            var types = rootObjects.Select(o => o.GetType()).Distinct().ToArray();
+            if (types.Length == 1)
             {
                 elementDescription = types[0].Name;
             }
 
-            var lblFilter = new Label(){
+            var lblFilter = new Label()
+            {
                 Text = "Filter:",
                 X = 1,
             };
-            var tbFilter = new TextField(){
+            var tbFilter = new TextField()
+            {
                 X = Pos.Right(lblFilter),
                 Width = Dim.Fill(1),
                 Text = applicationData.Filter ?? string.Empty
             };
             tbFilter.CursorPosition = tbFilter.Text.Length;
 
-            tbFilter.TextChanged += (_)=>{
+            tbFilter.TextChanged += (_) =>
+            {
                 filter.Text = tbFilter.Text.ToString();
             };
 
-            
+
             filterErrorLabel = new Label(string.Empty)
             {
                 X = Pos.Right(lblFilter) + 1,
@@ -101,7 +104,7 @@ namespace OutGridView.Cmdlet
                 Width = Dim.Fill() - lblFilter.Text.Length
             };
 
-            if(!applicationData.MinUI)
+            if (!applicationData.MinUI)
             {
                 Add(lblFilter);
                 Add(tbFilter);
@@ -111,18 +114,18 @@ namespace OutGridView.Cmdlet
             int pos = 0;
             statusBar.AddItemAt(pos++, new StatusItem(Key.Esc, "~ESC~ Close", () => Application.RequestStop()));
 
-            var siCount = new StatusItem(Key.Null, $"{rootObjects.Count} {elementDescription}",null);
-            selectedStatusBarItem = new StatusItem(Key.Null, string.Empty,null);
-            statusBar.AddItemAt(pos++,siCount);
-            statusBar.AddItemAt(pos++,selectedStatusBarItem);
+            var siCount = new StatusItem(Key.Null, $"{rootObjects.Count} {elementDescription}", null);
+            selectedStatusBarItem = new StatusItem(Key.Null, string.Empty, null);
+            statusBar.AddItemAt(pos++, siCount);
+            statusBar.AddItemAt(pos++, selectedStatusBarItem);
 
-            if ( applicationData.Debug)
+            if (applicationData.Debug)
             {
-                statusBar.AddItemAt(pos++,new StatusItem(Key.Null, $" v{applicationData.ModuleVersion}", null));
-                statusBar.AddItemAt(pos++,new StatusItem(Key.Null, 
+                statusBar.AddItemAt(pos++, new StatusItem(Key.Null, $" v{applicationData.ModuleVersion}", null));
+                statusBar.AddItemAt(pos++, new StatusItem(Key.Null,
                 $"{Application.Driver} v{FileVersionInfo.GetVersionInfo(Assembly.GetAssembly(typeof(Application)).Location).ProductVersion}", null));
             }
-                        
+
             statusBar.Visible = !applicationData.MinUI;
             Application.Top.Add(statusBar);
 
@@ -130,7 +133,7 @@ namespace OutGridView.Cmdlet
         }
         private void SetRegexError(string error)
         {
-            if(string.Equals(error, filterErrorLabel.Text.ToString()))
+            if (string.Equals(error, filterErrorLabel.Text.ToString()))
             {
                 return;
             }
@@ -142,13 +145,13 @@ namespace OutGridView.Cmdlet
         private void SelectionChanged(object sender, SelectionChangedEventArgs<object> e)
         {
             var selectedValue = e.NewValue;
-            
-            if( selectedValue is CachedMemberResult cmr)
+
+            if (selectedValue is CachedMemberResult cmr)
             {
                 selectedValue = cmr.Value;
             }
 
-            if(selectedValue != null && selectedStatusBarItem != null)
+            if (selectedValue != null && selectedStatusBarItem != null)
             {
                 selectedStatusBarItem.Title = selectedValue.GetType().Name;
             }
@@ -156,21 +159,21 @@ namespace OutGridView.Cmdlet
             {
                 selectedStatusBarItem.Title = string.Empty;
             }
-            
+
             statusBar.SetNeedsDisplay();
         }
 
         private string AspectGetter(object toRender)
         {
-            if(toRender is Process p)
+            if (toRender is Process p)
             {
                 return p.ProcessName;
             }
-            if(toRender is null)
+            if (toRender is null)
             {
                 return "Null";
             }
-            if(toRender is FileSystemInfo fsi && !IsRootObject(fsi))
+            if (toRender is FileSystemInfo fsi && !IsRootObject(fsi))
             {
                 return fsi.Name;
             }
@@ -201,9 +204,9 @@ namespace OutGridView.Cmdlet
 
         public IEnumerable<object> GetChildren(object forObject)
         {
-            if(forObject is CachedMemberResult p) 
+            if (forObject is CachedMemberResult p)
             {
-                if(p.IsCollection)
+                if (p.IsCollection)
                 {
                     return p.Elements;
                 }
@@ -211,29 +214,30 @@ namespace OutGridView.Cmdlet
                 return GetChildren(p.Value);
             }
 
-            if(forObject is CachedMemberResultElement e)
+            if (forObject is CachedMemberResultElement e)
             {
                 return GetChildren(e.Value);
             }
 
             List<object> children = new List<object>();
-            
-            foreach(var member in forObject.GetType().GetMembers().OrderBy(m=>m.Name))
+
+            foreach (var member in forObject.GetType().GetMembers().OrderBy(m => m.Name))
             {
-                if(member is PropertyInfo prop)
+                if (member is PropertyInfo prop)
                 {
                     children.Add(new CachedMemberResult(forObject, prop));
                 }
-                if(member is FieldInfo field)
+                if (member is FieldInfo field)
                 {
                     children.Add(new CachedMemberResult(forObject, field));
                 }
             }
 
-            try{
+            try
+            {
                 children.AddRange(GetExtraChildren(forObject));
             }
-            catch(Exception)
+            catch (Exception)
             {
                 // Extra children unavailable, possibly security or IO exceptions enumerating children etc
             }
@@ -243,9 +247,9 @@ namespace OutGridView.Cmdlet
 
         private IEnumerable<object> GetExtraChildren(object forObject)
         {
-            if(forObject is DirectoryInfo dir)
+            if (forObject is DirectoryInfo dir)
             {
-                foreach(var c in dir.EnumerateFileSystemInfos())
+                foreach (var c in dir.EnumerateFileSystemInfos())
                 {
                     yield return c;
                 }
@@ -259,14 +263,15 @@ namespace OutGridView.Cmdlet
             Application.UseSystemConsole = applicationData.UseNetDriver;
             Application.Init();
             Window window = null;
-            
+
             try
-            {                
-                window = new ShowObjectView(objects.Select(p=>p.BaseObject).ToList(), applicationData);
+            {
+                window = new ShowObjectView(objects.Select(p => p.BaseObject).ToList(), applicationData);
                 Application.Top.Add(window);
                 Application.Run();
             }
-            finally{
+            finally
+            {
                 Application.Shutdown();
                 window?.Dispose();
             }
@@ -284,7 +289,8 @@ namespace OutGridView.Cmdlet
                 Index = index;
                 Value = value;
 
-                try{
+                try
+                {
                     representation = Value?.ToString() ?? "Null";
                 }
                 catch (Exception)
@@ -303,10 +309,10 @@ namespace OutGridView.Cmdlet
             public MemberInfo Member;
             public object Value;
             public object Parent;
-            private string representation;            
+            private string representation;
             private List<CachedMemberResultElement> valueAsList;
 
-            
+
             public bool IsCollection => valueAsList != null;
             public IReadOnlyCollection<CachedMemberResultElement> Elements => valueAsList?.AsReadOnly();
 
@@ -329,7 +335,7 @@ namespace OutGridView.Cmdlet
                     {
                         throw new NotSupportedException($"Unknown {nameof(MemberInfo)} Type");
                     }
-                    
+
                     representation = ValueToString();
 
                 }
@@ -341,20 +347,22 @@ namespace OutGridView.Cmdlet
 
             private string ValueToString()
             {
-                if(Value == null)
+                if (Value == null)
                 {
                     return "Null";
                 }
-                try{
-                    if(IsCollectionOfKnownTypeAndSize(out Type elementType, out int size))
+                try
+                {
+                    if (IsCollectionOfKnownTypeAndSize(out Type elementType, out int size))
                     {
                         return $"{elementType.Name}[{size}]";
                     }
-                }catch(Exception)
+                }
+                catch (Exception)
                 {
                     return Value?.ToString();
                 }
-                
+
 
                 return Value?.ToString();
             }
@@ -364,28 +372,28 @@ namespace OutGridView.Cmdlet
                 elementType = null;
                 size = 0;
 
-                if(Value == null || Value is string)
+                if (Value == null || Value is string)
                 {
-                    
+
                     return false;
                 }
 
-                if(Value is IEnumerable ienumerable)
+                if (Value is IEnumerable ienumerable)
                 {
                     var list = ienumerable.Cast<object>().ToList();
 
-                    var types = list.Where(v=>v!=null).Select(v=>v.GetType()).Distinct().ToArray();
+                    var types = list.Where(v => v != null).Select(v => v.GetType()).Distinct().ToArray();
 
-                    if(types.Length == 1)
+                    if (types.Length == 1)
                     {
                         elementType = types[0];
                         size = list.Count;
 
-                        valueAsList = list.Select((e,i)=>new CachedMemberResultElement(e,i)).ToList();
+                        valueAsList = list.Select((e, i) => new CachedMemberResultElement(e, i)).ToList();
                         return true;
                     }
                 }
-                
+
                 return false;
             }
 
@@ -399,41 +407,45 @@ namespace OutGridView.Cmdlet
             private readonly ShowObjectView parent;
             readonly TreeView<object> _forTree;
 
-            public RegexTreeViewTextFilter (ShowObjectView parent, TreeView<object> forTree)
+            public RegexTreeViewTextFilter(ShowObjectView parent, TreeView<object> forTree)
             {
                 this.parent = parent;
-                _forTree = forTree ?? throw new ArgumentNullException (nameof (forTree));
+                _forTree = forTree ?? throw new ArgumentNullException(nameof(forTree));
             }
 
             private string text;
 
-            public string Text {
+            public string Text
+            {
                 get { return text; }
-                set {
+                set
+                {
                     text = value;
-                    RefreshTreeView ();
+                    RefreshTreeView();
                 }
             }
 
-            private void RefreshTreeView ()
+            private void RefreshTreeView()
             {
-                _forTree.InvalidateLineMap ();
-                _forTree.SetNeedsDisplay ();
+                _forTree.InvalidateLineMap();
+                _forTree.SetNeedsDisplay();
             }
 
-            public bool IsMatch (object model)
+            public bool IsMatch(object model)
             {
-                if (string.IsNullOrWhiteSpace (Text)) {
+                if (string.IsNullOrWhiteSpace(Text))
+                {
                     return true;
                 }
 
                 parent.SetRegexError(string.Empty);
 
-                var modelText = _forTree.AspectGetter (model);
-                try{
+                var modelText = _forTree.AspectGetter(model);
+                try
+                {
                     return Regex.IsMatch(modelText, text, RegexOptions.IgnoreCase);
                 }
-                catch(RegexParseException e)
+                catch (RegexParseException e)
                 {
                     parent.SetRegexError(e.Message);
                     return true;

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/TypeGetter.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/TypeGetter.cs
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Internal;
-using System.Linq;
-using System.Globalization;
-using System.Collections.Generic;
+
 using Microsoft.PowerShell.Commands;
+
 using OutGridView.Models;
-using System.Text.RegularExpressions;
 
 namespace OutGridView.Cmdlet
 {
@@ -44,7 +45,7 @@ namespace OutGridView.Cmdlet
             return extendedTypeDefinition.FormatViewDefinition[0];
         }
 
-        public DataTableRow CastObjectToDataTableRow(PSObject ps, List<DataTableColumn> dataColumns, int objectIndex)
+        public static DataTableRow CastObjectToDataTableRow(PSObject ps, List<DataTableColumn> dataColumns, int objectIndex)
         {
             Dictionary<string, IValue> valuePairs = new Dictionary<string, IValue>();
 
@@ -72,7 +73,7 @@ namespace OutGridView.Cmdlet
             return new DataTableRow(valuePairs, objectIndex);
         }
 
-        private void SetTypesOnDataColumns(List<DataTableRow> dataTableRows, List<DataTableColumn> dataTableColumns)
+        private static void SetTypesOnDataColumns(List<DataTableRow> dataTableRows, List<DataTableColumn> dataTableColumns)
         {
             var dataRows = dataTableRows.Select(x => x.Values);
 
@@ -187,7 +188,7 @@ namespace OutGridView.Cmdlet
             "System.Security.SecureString",
             "System.Numerics.BigInteger"
         };
-        private bool PSObjectIsPrimitive(PSObject ps)
+        private static bool PSObjectIsPrimitive(PSObject ps)
         {
             var psBaseType = ps.BaseObject.GetType();
 


### PR DESCRIPTION
Ran "Format Document" and "Sort Usings" via VS Code just to get things cleaned up, then applied automatic fixes where possible, otherwise it was adding `sealed` to the classes the build was complaining about and `GC.SuppressFinalize(this)`.