### PR TITLE
Change alias "sot" to "shot"

### DIFF
--- a/docs/Microsoft.PowerShell.ConsoleGuiTools/Show-ObjectTree.md
+++ b/docs/Microsoft.PowerShell.ConsoleGuiTools/Show-ObjectTree.md
@@ -44,7 +44,7 @@ This command gets the processes running on the local computer and sends them to 
 ### Example 2: Save output to a variable, and then output a tree view
 
 ```PowerShell
-PS C:\> ($A = Get-ChildItem -Path $pshome -Recurse) | sot
+PS C:\> ($A = Get-ChildItem -Path $pshome -Recurse) | shot
 ```
 
 This command saves its output in a variable and sends it to **Show-ObjectTree**.

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/Microsoft.PowerShell.ConsoleGuiTools.psd1
@@ -76,7 +76,7 @@ CmdletsToExport = @( 'Out-ConsoleGridView', 'Show-ObjectTree' )
 VariablesToExport = '*'
 
 # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-AliasesToExport = @( 'ocgv', 'sot' )
+AliasesToExport = @( 'ocgv', 'shot' )
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()
@@ -151,7 +151,7 @@ If items are selected, then a filter is applied, items now hidden stay selected 
 * PSAnsiRenderingFileInfo causes display issues with Out-ConsoleGridView #159
 * Removes building and distribution of Out-GridView and the other Avalonia-based components
 * Remove ANSI escape sequences from property values #158
-        
+
 ## v0.7.0
 
 Upgraded to PowerShell 7.2 and .NET target framework `net60`

--- a/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectTreeCmdletCommand.cs
+++ b/src/Microsoft.PowerShell.ConsoleGuiTools/ShowObjectTreeCmdletCommand.cs
@@ -12,7 +12,7 @@ using OutGridView.Models;
 namespace OutGridView.Cmdlet
 {
     [Cmdlet("Show", "ObjectTree")]
-    [Alias("sot")]
+    [Alias("shot")]
     public class ShowObjectTreeCmdletCommand : PSCmdlet, IDisposable
     {
         #region Properties
@@ -51,7 +51,7 @@ namespace OutGridView.Cmdlet
         [Parameter(HelpMessage = "If specified no window frame, filter box, or status bar will be displayed in the GUI.")]
         public SwitchParameter MinUI { set; get; }
         /// <summary>
-        /// gets or sets the whether the Terminal.Gui System.Net.Console-based ConsoleDriver will be used instead of the 
+        /// gets or sets the whether the Terminal.Gui System.Net.Console-based ConsoleDriver will be used instead of the
         /// default platform-specific (Windows or Curses) ConsoleDriver.
         /// </summary>
         [Parameter(HelpMessage = "If specified the Terminal.Gui System.Net.Console-based ConsoleDriver (NetDriver) will be used.")]


### PR DESCRIPTION
# PR Summary

Change the alias for the command "Show-ObjectTree" from "sot" to "shot".

Fixes #228

## PR Context

The canonical alias for the verb "Show" is "sh" (not "s").

See:

```plaintext
PS> Get-Verb Set, Show

Verb AliasPrefix Group  Description
---- ----------- -----  -----------
Set  s           Common Replaces data on an existing resource or creates a resource that contains some data
Show sh          Common Makes a resource visible to the user
```